### PR TITLE
Make `operator_co_await_example.cpp` compile

### DIFF
--- a/libraries/concurrency/future/future/operator_co_await_example.cpp
+++ b/libraries/concurrency/future/future/operator_co_await_example.cpp
@@ -1,5 +1,5 @@
 
-#define STLAB_FUTURE_COROUTINE_SUPPORT
+#define STLAB_FUTURE_COROUTINES 1
 
 #include <iostream>
 


### PR DESCRIPTION
The example for `operator co_await` does not compile:
https://stlab.cc/libraries/concurrency/future/future/operator_co_await.html